### PR TITLE
Bug fix for OS platform

### DIFF
--- a/QGISPlugin/MilkMachine/milkmachine.py
+++ b/QGISPlugin/MilkMachine/milkmachine.py
@@ -378,7 +378,7 @@ class MilkMachine:
                         UserOs = platform.platform()
                         WindOs = re.search('Windows', UserOs, re.I)
                         if WindOs.group():
-							self.pp = subprocess.Popen(["C:/Program Files (x86)/VideoLAN/VLC/vlc.exe", wav_path, "--start-time", str(jumptime)], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                            self.pp = subprocess.Popen(["C:/Program Files (x86)/VideoLAN/VLC/vlc.exe", wav_path, "--start-time", str(jumptime)], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                         else:
                             self.pp = subprocess.Popen(["/Applications/VLC.app/Contents/MacOS/VLC", self.line_audiopath, "--start-time", str(jumptime)], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                         NOW = datetime.datetime.now()


### PR DESCRIPTION
The call to WindOs.group() is not valid when it is Mac since it will be NoneType. This is fixed with just a boolean test for existence rather than specific text matching.
